### PR TITLE
Remark about CacheMe only about Latex like code.

### DIFF
--- a/doc/robust-externalize.tex
+++ b/doc/robust-externalize.tex
@@ -618,7 +618,7 @@ If you only care about \tikzname's picture, you have 3 options:
   |\cacheCommand{yourcommand}[O{default val}m]{your preset options}|\\
   (|O{default val}m| means that the command accepts one optional argument with default value |default val| and one mandatory argument) but \textbf{we do recommend} to use |\cacheCommand| to cache |\tikz| since |\tikz| has a quite complicated parsing strategy (e.g.\ you can write |\tikz[options] \node{foo};| which has no mandatory argument enclosed in |{}|). |\cacheTikz| takes care of this already and caches both the environment |\begin{tikzpicture}| and the macro |\tikz|.
 \item Use |tikzpictureC| instead of |tikzpicture| (this is mostly done to easily convert existing code to this library, but works only for |tikz| pictures).
-\item Use the more general |CacheMe| environment, that can cache \tikzname, \LaTeX{}, python, and much more.
+\item Use the more general |CacheMe| environment, that can cache \tikzname, \LaTeX{} and much more \LaTeX{} like code.
 \end{enumerate}
 
 These 4 options are illustrated below (note that all commands accept a first optional argument enclosed in |<...>| that contains the options to pass to |CacheMe| after loading the |tikzpicture| preset, that loads itself the |tikz| preset first):


### PR DESCRIPTION
I changed the line on page 15 About the use of CacheMe. It said, that CacheMe can be used to cache Latex, tikz, python and much more. But as far as I understand it, CacheMe can only cache latex like code and not python, is that correct?